### PR TITLE
Add Swagger2 configurations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,12 +64,17 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger2</artifactId>
-            <version>2.6.1</version>
+            <version>${swagger.version}</version>
         </dependency>
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.6.1</version>
+            <version>${swagger.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-bean-validators</artifactId>
+            <version>${swagger.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>
@@ -107,5 +112,6 @@
 
     <properties>
         <java.version>1.8</java.version>
+        <swagger.version>2.9.2</swagger.version>
     </properties>
 </project>

--- a/src/main/java/org/sefglobal/scholarx/config/SwaggerConfig.java
+++ b/src/main/java/org/sefglobal/scholarx/config/SwaggerConfig.java
@@ -1,0 +1,46 @@
+package org.sefglobal.scholarx.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import springfox.bean.validators.configuration.BeanValidatorPluginsConfiguration;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.Contact;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import java.util.Collections;
+
+@Configuration
+@EnableSwagger2
+@Import(BeanValidatorPluginsConfiguration.class)
+public class SwaggerConfig {
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("org.sefglobal.scholarx.controller"))
+                .paths(PathSelectors.any())
+                .build()
+                .apiInfo(apiInfo());
+    }
+
+    private ApiInfo apiInfo() {
+        Contact contact = new Contact("SEF",
+                                      "https://sefglobal.org",
+                                      "sustainableedufoundation@gmail.com");
+        return new ApiInfo("ScholarX API",
+                           "Backend APIs of ScholarX platform.",
+                           "0.0.1-SNAPSHOT",
+                           null,
+                           contact,
+                           "MIT License",
+                           "https://github.com/sef-global/scholarx/blob/master/LICENSE",
+                           Collections.emptyList());
+    }
+
+}


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix #24 

## Goals
Backend documentation should be autogenerated through Swagger2.

## Approach
1. Added the necessary dependencies(`springfox-swagger2`, `springfox-swagger-ui`,  `springfox-bean-validators`).
2. Created a configuration class for Swagger with some customized Beans.

### Screenshots
![image](https://user-images.githubusercontent.com/36471249/91653690-93a66f00-eac0-11ea-930f-9a7a1a9fb53a.png)

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related PRs
N/A

## Test environment
macOS 10.15, JDK 1.8

## Learning
Swagger2 with SpringBoot