### PR TITLE
Change directory of admin API unit tests

### DIFF
--- a/src/test/java/org/sefglobal/scholarx/controller/ProgramControllerTest.java
+++ b/src/test/java/org/sefglobal/scholarx/controller/ProgramControllerTest.java
@@ -1,122 +1,25 @@
 package org.sefglobal.scholarx.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.sefglobal.scholarx.controller.admin.ProgramController;
 import org.sefglobal.scholarx.exception.ResourceNotFoundException;
-import org.sefglobal.scholarx.model.Program;
 import org.sefglobal.scholarx.service.ProgramService;
-import org.sefglobal.scholarx.util.ProgramState;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = {ProgramController.class, org.sefglobal.scholarx.controller.ProgramController.class})
+@WebMvcTest(ProgramController.class)
 public class ProgramControllerTest {
     @Autowired
     private MockMvc mockMvc;
-    @Autowired
-    private ObjectMapper objectMapper;
     @MockBean
     private ProgramService programService;
     private final Long programId = 1L;
-    private final Program program
-            = new Program("SCHOLARX-2020",
-                          "SCHOLARX program of 2020",
-                          "http://scholarx/images/SCHOLARX-2020",
-                          "http://scholarx/SCHOLARX-2020/home",
-                          ProgramState.CREATED);
-
-    @Test
-    void addProgram_withValidData_thenReturns201() throws Exception {
-        mockMvc.perform(post("/admin/programs")
-                                .contentType("application/json")
-                                .content(objectMapper.writeValueAsString(program)))
-               .andExpect(status().isCreated());
-    }
-
-    @Test
-    void addProgram_withValidData_thenReturnsValidResponseBody() throws Exception {
-        mockMvc.perform(post("/admin/programs")
-                                .contentType("application/json")
-                                .content(objectMapper.writeValueAsString(program)))
-               .andReturn();
-
-        ArgumentCaptor<Program> programCaptor = ArgumentCaptor.forClass(Program.class);
-        verify(programService, times(1)).addProgram(programCaptor.capture());
-
-        program.setState(null);
-        String expectedResponse = objectMapper.writeValueAsString(program);
-        String actualResponse = objectMapper.writeValueAsString(programCaptor.getValue());
-        assertThat(actualResponse).isEqualTo(expectedResponse);
-    }
-
-    @Test
-    void updateState_withValidData_thenReturns200() throws Exception {
-        mockMvc.perform(put("/admin/programs/{id}/state", programId)
-                                .contentType("application/json")
-                                .content(objectMapper.writeValueAsString(program.getState())))
-               .andExpect(status().isOk());
-    }
-
-    @Test
-    void updateState_withUnavailableData_thenReturn404() throws Exception {
-        doThrow(ResourceNotFoundException.class)
-                .when(programService)
-                .updateState(anyLong());
-
-        mockMvc.perform(put("/admin/programs/{id}/state", programId)
-                                .contentType("application/json")
-                                .content(objectMapper.writeValueAsString(program.getState())))
-               .andExpect(status().isNotFound());
-    }
-
-    @Test
-    void updateProgram_withValidData_thenReturns200() throws Exception {
-        mockMvc.perform(put("/admin/programs/{id}", programId)
-                                .contentType("application/json")
-                                .content(objectMapper.writeValueAsString(program)))
-               .andExpect(status().isOk());
-    }
-
-    @Test
-    void updateProgram_withUnavailableData_thenReturn404() throws Exception {
-        doThrow(ResourceNotFoundException.class)
-                .when(programService)
-                .updateProgram(anyLong(), any(Program.class));
-
-        mockMvc.perform(put("/admin/programs/{id}", programId)
-                                .contentType("application/json")
-                                .content(objectMapper.writeValueAsString(program)))
-               .andExpect(status().isNotFound());
-    }
-
-    @Test
-    void deleteProgram_withValidData_thenReturns204() throws Exception {
-        mockMvc.perform(delete("/admin/programs/{id}", programId))
-               .andExpect(status().isNoContent());
-    }
-
-    @Test
-    void deleteProgram_withUnavailableData_thenReturn404() throws Exception {
-        doThrow(ResourceNotFoundException.class)
-                .when(programService)
-                .deleteProgram(anyLong());
-
-        mockMvc.perform(delete("/admin/programs/{id}", programId))
-               .andExpect(status().isNotFound());
-    }
 
     @Test
     void getPrograms_withValidData_thenReturns200() throws Exception {

--- a/src/test/java/org/sefglobal/scholarx/controller/admin/MenteeControllerTest.java
+++ b/src/test/java/org/sefglobal/scholarx/controller/admin/MenteeControllerTest.java
@@ -1,4 +1,4 @@
-package org.sefglobal.scholarx.controller;
+package org.sefglobal.scholarx.controller.admin;
 
 import org.junit.jupiter.api.Test;
 import org.sefglobal.scholarx.controller.admin.MenteeController;

--- a/src/test/java/org/sefglobal/scholarx/controller/admin/MentorControllerTest.java
+++ b/src/test/java/org/sefglobal/scholarx/controller/admin/MentorControllerTest.java
@@ -1,4 +1,4 @@
-package org.sefglobal.scholarx.controller;
+package org.sefglobal.scholarx.controller.admin;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #51 

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
Move the unit tests of admin apis to the admin/ directory

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
Moved the test controllers to a new directory
Kept the common program unit tests outside the directory

Previous structure:

├── controller
│   ├── MenteeControllerTest.java
│   ├── MentorControllerTest.java
│   └── ProgramControllerTest.java
└── service
    ├── MenteeServiceTest.java
    ├── MentorServiceTest.java
    └── ProgramServiceTest.java


New structure:

├── controller
│   ├── admin
│   │   ├── MenteeControllerTest.java
│   │   ├── MentorControllerTest.java
│   │   └── ProgramControllerTest.java
│   └── ProgramControllerTest.java
└── service
    ├── MenteeServiceTest.java
    ├── MentorServiceTest.java
    └── ProgramServiceTest.java

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Related PRs
<!--- List any other related PRs --> 
N/A

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 
Ubuntu 19.04
OpenJDK 1.8

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
N/A
