### PR TITLE
Approving/Rejecting non PENDING mentors/mentees

### DIFF
--- a/src/main/java/org/sefglobal/scholarx/service/MenteeService.java
+++ b/src/main/java/org/sefglobal/scholarx/service/MenteeService.java
@@ -42,11 +42,11 @@ public class MenteeService {
      * Update a {@link EnrolmentState} of a {@link Mentee} to Approved or Rejected
      *
      * @param menteeId   which is the {@link Mentee} to be updated
-     * @param isApproved which states whether the {@link Mentee} to be approved or not
+     * @param isApproved which states whether the {@link Mentee} to be approved or rejected
      * @return the updated {@link Mentee}
      *
      * @throws ResourceNotFoundException is thrown if the {@link Mentee} doesn't exist
-     * @throws BadRequestException       is thrown if the {@link Mentee} is not in valid state
+     * @throws BadRequestException       is thrown if the {@link Mentee} is removed
      */
     public Mentee approveOrRejectMentee(long menteeId, boolean isApproved)
             throws ResourceNotFoundException, BadRequestException {
@@ -57,18 +57,14 @@ public class MenteeService {
             log.error(msg);
             throw new ResourceNotFoundException(msg);
         }
-        if (!(EnrolmentState.PENDING.equals(optionalMentee.get().getState()))) {
+        if (EnrolmentState.REMOVED.equals(optionalMentee.get().getState())) {
             String msg = "Error, Mentee cannot be approved/rejected. " +
-                         "Mentee with id: " + menteeId + " is not in the valid state.";
+                         "Mentee with id: " + menteeId + " is removed.";
             log.error(msg);
             throw new BadRequestException(msg);
         }
 
-        if (isApproved) {
-            optionalMentee.get().setState(EnrolmentState.APPROVED);
-        } else {
-            optionalMentee.get().setState(EnrolmentState.REJECTED);
-        }
+        optionalMentee.get().setState(isApproved?EnrolmentState.APPROVED:EnrolmentState.REJECTED);
         return menteeRepository.save(optionalMentee.get());
     }
 }


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix #74 

## Goals
Mentors/mentees that are not in `PENDING` state should be able to be approved/rejected.

## Approach
Changed the service logic(`if` conditions) to be able to change the mentor/mentee state if the state is not `PENDING`.

### Screenshots
N/A
  
### Preview Link
N/A

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related PRs
N/A

## Test environment

## Learning
N/A