### PR TITLE
Update two remaining endpoints to get JSON RequestBody

### DIFF
--- a/src/main/java/org/sefglobal/scholarx/controller/MenteeController.java
+++ b/src/main/java/org/sefglobal/scholarx/controller/MenteeController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/mentees")
@@ -24,12 +25,15 @@ public class MenteeController {
         this.menteeService = menteeService;
     }
 
-
     @PutMapping("/{id}/state")
     @ResponseStatus(HttpStatus.OK)
     public Mentee approveOrRejectMentee(@PathVariable long id,
-                                        @Valid @RequestBody boolean isApproved)
+                                        @Valid @RequestBody Map<String, Boolean> payload)
             throws ResourceNotFoundException, BadRequestException {
-        return menteeService.approveOrRejectMentee(id, isApproved);
+        if (!payload.containsKey("isApproved")) {
+            String msg = "Error, Value cannot be null.";
+            throw new BadRequestException(msg);
+        }
+        return menteeService.approveOrRejectMentee(id, payload.get("isApproved"));
     }
 }

--- a/src/main/java/org/sefglobal/scholarx/controller/admin/MentorController.java
+++ b/src/main/java/org/sefglobal/scholarx/controller/admin/MentorController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
+import java.util.Map;
 
 @RestController("MentorAdminController")
 @RequestMapping("/admin/mentors")
@@ -27,8 +28,8 @@ public class MentorController {
     @PutMapping("/{id}/state")
     @ResponseStatus(HttpStatus.OK)
     public Mentor updateState(@PathVariable long id,
-                              @Valid @RequestBody EnrolmentState enrolmentState)
+                              @Valid @RequestBody Map<String, EnrolmentState> payload)
             throws ResourceNotFoundException {
-        return mentorService.updateState(id, enrolmentState);
+        return mentorService.updateState(id, payload.get("state"));
     }
 }

--- a/src/main/java/org/sefglobal/scholarx/service/MenteeService.java
+++ b/src/main/java/org/sefglobal/scholarx/service/MenteeService.java
@@ -47,9 +47,15 @@ public class MenteeService {
      *
      * @throws ResourceNotFoundException is thrown if the {@link Mentee} doesn't exist
      * @throws BadRequestException       is thrown if the {@link Mentee} is removed
+     * @throws BadRequestException       is thrown if the {@link Boolean} is null
      */
-    public Mentee approveOrRejectMentee(long menteeId, boolean isApproved)
+    public Mentee approveOrRejectMentee(long menteeId, Boolean isApproved)
             throws ResourceNotFoundException, BadRequestException {
+        if (null == isApproved){
+            String msg = "Error, Value cannot be null.";
+            log.error(msg);
+            throw new BadRequestException(msg);
+        }
         Optional<Mentee> optionalMentee = menteeRepository.findById(menteeId);
         if (!optionalMentee.isPresent()) {
             String msg = "Error, Mentee cannot be approved/rejected. " +

--- a/src/test/java/org/sefglobal/scholarx/controller/MenteeControllerTest.java
+++ b/src/test/java/org/sefglobal/scholarx/controller/MenteeControllerTest.java
@@ -11,6 +11,9 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doThrow;
@@ -46,33 +49,39 @@ public class MenteeControllerTest {
 
     @Test
     void approveOrRejectMentee_withValidData_thenReturns200() throws Exception {
+        Map<String, Boolean> payload = new HashMap<>();
+        payload.put("isApproved", true);
         mockMvc.perform(put("/mentees/{menteeId}/state", menteeId)
                 .contentType("application/json")
-                .content(objectMapper.writeValueAsString(true)))
+                .content(objectMapper.writeValueAsString(payload)))
                 .andExpect(status().isOk());
     }
 
     @Test
     void approveOrRejectMentee_withUnavailableData_thenReturn404() throws Exception {
+        Map<String, Boolean> payload = new HashMap<>();
+        payload.put("isApproved", true);
         doThrow(ResourceNotFoundException.class)
                 .when(menteeService)
                 .approveOrRejectMentee(anyLong(), anyBoolean());
 
         mockMvc.perform(put("/mentees/{menteeId}/state", menteeId)
                 .contentType("application/json")
-                .content(objectMapper.writeValueAsString(true)))
+                .content(objectMapper.writeValueAsString(payload)))
                 .andExpect(status().isNotFound());
     }
 
     @Test
     void approveOrRejectMentee_withUnsuitableData_thenReturn400() throws Exception {
+        Map<String, Boolean> payload = new HashMap<>();
+        payload.put("isApproved", true);
         doThrow(BadRequestException.class)
                 .when(menteeService)
                 .approveOrRejectMentee(anyLong(), anyBoolean());
 
         mockMvc.perform(put("/mentees/{menteeId}/state", menteeId)
                 .contentType("application/json")
-                .content(objectMapper.writeValueAsString(true)))
+                .content(objectMapper.writeValueAsString(payload)))
                 .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/org/sefglobal/scholarx/controller/MentorControllerTest.java
+++ b/src/test/java/org/sefglobal/scholarx/controller/MentorControllerTest.java
@@ -17,6 +17,9 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import javax.servlet.http.Cookie;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -61,21 +64,25 @@ public class MentorControllerTest {
 
     @Test
     void updateState_withValidData_thenReturns200() throws Exception {
+        Map<String, EnrolmentState> payload = new HashMap<>();
+        payload.put("state", EnrolmentState.APPROVED);
         mockMvc.perform(put("/admin/mentors/{id}/state", mentorId)
                 .contentType("application/json")
-                .content(objectMapper.writeValueAsString(EnrolmentState.APPROVED)))
+                .content(objectMapper.writeValueAsString(payload)))
                 .andExpect(status().isOk());
     }
 
     @Test
     void updateState_withUnavailableData_thenReturn404() throws Exception {
+        Map<String, EnrolmentState> payload = new HashMap<>();
+        payload.put("state", EnrolmentState.APPROVED);
         doThrow(ResourceNotFoundException.class)
                 .when(mentorService)
                 .updateState(anyLong(), any(EnrolmentState.class));
 
         mockMvc.perform(put("/admin/mentors/{id}/state", mentorId)
                 .contentType("application/json")
-                .content(objectMapper.writeValueAsString(EnrolmentState.APPROVED)))
+                .content(objectMapper.writeValueAsString(payload)))
                 .andExpect(status().isNotFound());
     }
 


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #84 

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
Update two remaining endpoints to get JSON RequestBody in following APIs
1. Approve or reject mentee
2. Update state of mentor

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
Added Map<> object as the Request Body
Updated the unit tests

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related PRs
<!--- List any other related PRs --> 
N/A

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 
Ubuntu 19.04
OpenJDK 1.8

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
Discussion:
https://sef.discourse.group/t/building-a-mock-api-server-for-the-scholarx-api/186/9

