### PR TITLE
Create user api to get a logged in user's mentees

### DIFF
--- a/src/main/java/org/sefglobal/scholarx/controller/IntrospectionController.java
+++ b/src/main/java/org/sefglobal/scholarx/controller/IntrospectionController.java
@@ -3,13 +3,17 @@ package org.sefglobal.scholarx.controller;
 import org.sefglobal.scholarx.exception.NoContentException;
 import org.sefglobal.scholarx.exception.ResourceNotFoundException;
 import org.sefglobal.scholarx.exception.UnauthorizedException;
+import org.sefglobal.scholarx.model.Mentee;
 import org.sefglobal.scholarx.model.Profile;
 import org.sefglobal.scholarx.model.Program;
 import org.sefglobal.scholarx.service.IntrospectionService;
+import org.sefglobal.scholarx.util.EnrolmentState;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -44,5 +48,15 @@ public class IntrospectionController {
     public List<Program> getMentoringPrograms(@CookieValue(value = "profileId") long profileId)
             throws ResourceNotFoundException, NoContentException {
         return introspectionService.getMentoringPrograms(profileId);
+    }
+
+    @GetMapping("/programs/{id}/mentees")
+    @ResponseStatus(HttpStatus.OK)
+    public List<Mentee> getMentees(@CookieValue long profileId,
+                                   @PathVariable long id,
+                                   @RequestParam(required = false)
+                                           List<EnrolmentState> menteeStates)
+            throws NoContentException {
+        return introspectionService.getMentees(id, profileId, menteeStates);
     }
 }

--- a/src/main/java/org/sefglobal/scholarx/controller/admin/ProgramController.java
+++ b/src/main/java/org/sefglobal/scholarx/controller/admin/ProgramController.java
@@ -52,13 +52,4 @@ public class ProgramController {
             throws ResourceNotFoundException {
         return programService.getAllMentorsByProgramId(id);
     }
-
-    @GetMapping("/{id}/mentor/mentees")
-    @ResponseStatus(HttpStatus.OK)
-    public List<Mentee> getMenteesOfMentor(@PathVariable long id,
-                                           @CookieValue(value = "profileId") long profileId,
-                                           @RequestParam(required = false) List<EnrolmentState> states)
-            throws ResourceNotFoundException {
-        return programService.getAllMenteesOfMentor(id, profileId, states);
-    }
 }

--- a/src/main/java/org/sefglobal/scholarx/repository/MenteeRepository.java
+++ b/src/main/java/org/sefglobal/scholarx/repository/MenteeRepository.java
@@ -16,9 +16,13 @@ import java.util.Optional;
 public interface MenteeRepository extends JpaRepository<Mentee, Long> {
 
     List<Mentee> findAllByMentorIdAndState(long id, EnrolmentState state);
+
     List<Mentee> findAllByMentorIdAndStateIn(long id, List<EnrolmentState> states);
+
     List<Mentee> findAllByProgramIdAndProfileId(long programId, long profileId);
+
     Optional<Mentee> findByProfileIdAndMentorId(long profileId, long mentorId);
+
     List<Mentee> findAllByProfileId(long profileId);
 
     @Modifying
@@ -32,4 +36,7 @@ public interface MenteeRepository extends JpaRepository<Mentee, Long> {
             nativeQuery = true
     )
     void deleteByMentorProgramId(long id);
+
+    List<Mentee> findAllByProgramIdAndProfileIdAndStateIn(long programId, long profileId,
+                                                          List<EnrolmentState> states);
 }

--- a/src/main/java/org/sefglobal/scholarx/service/IntrospectionService.java
+++ b/src/main/java/org/sefglobal/scholarx/service/IntrospectionService.java
@@ -10,6 +10,7 @@ import org.sefglobal.scholarx.model.Program;
 import org.sefglobal.scholarx.repository.MenteeRepository;
 import org.sefglobal.scholarx.repository.MentorRepository;
 import org.sefglobal.scholarx.repository.ProfileRepository;
+import org.sefglobal.scholarx.util.EnrolmentState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -124,5 +125,36 @@ public class IntrospectionService {
         programsList.addAll(programSet); // TODO: find another way to remove duplicates
 
         return programsList;
+    }
+
+    /**
+     * Retrieves all the {@link Mentee} objects of a {@link Profile}
+     *
+     * @param programId    which is the id of the {@link Program}
+     * @param profileId    which is the id of the {@link Profile}
+     * @param menteeStates which is the list of states that {@link Mentee} objects should be
+     *                     filtered from
+     * @return {@link List} of {@link Mentee} objects
+     *
+     * @throws NoContentException if {@link Mentor} objects doesn't exist
+     */
+    public List<Mentee> getMentees(long programId, long profileId,
+                                   List<EnrolmentState> menteeStates) throws NoContentException {
+        List<Mentee> mentees;
+
+        if (menteeStates == null || menteeStates.isEmpty()) {
+            mentees = menteeRepository.findAllByProgramIdAndProfileId(programId, profileId);
+        } else {
+            mentees = menteeRepository
+                    .findAllByProgramIdAndProfileIdAndStateIn(programId, profileId, menteeStates);
+        }
+
+        if (mentees.isEmpty()) {
+            String msg = "No mentees exist for the required program: " + programId +
+                         " for the profile: " + profileId;
+            log.warn(msg);
+            throw new NoContentException(msg);
+        }
+        return mentees;
     }
 }

--- a/src/main/java/org/sefglobal/scholarx/service/ProgramService.java
+++ b/src/main/java/org/sefglobal/scholarx/service/ProgramService.java
@@ -278,33 +278,6 @@ public class ProgramService {
     }
 
     /**
-     * Retrieves all the {@link Mentee} objects of a {@link Mentor}
-     *
-     * @param programId which is the program id of the {@link Program}
-     * @param profileId which is the profile id of the {@link Mentor}
-     * @param states    which is the list of states of the {@link Mentee} objects to be filtered
-     * @return {@link List} of {@link Mentee} objects filtered by {@link Mentee} and {@link EnrolmentState}
-     *
-     * @throws ResourceNotFoundException if the requesting {@link Mentor} object doesn't exist
-     */
-    public List<Mentee> getAllMenteesOfMentor(long programId, long profileId, List<EnrolmentState> states)
-            throws ResourceNotFoundException {
-        Optional<Mentor> optionalMentor = mentorRepository.findByProfileIdAndProgramId(profileId, programId);
-        if (!optionalMentor.isPresent()) {
-            String msg = "Error, Mentor by profile id: " + profileId + " and " +
-                    "program id: " + programId + " cannot be updated. " +
-                    "Mentor doesn't exist.";
-            log.error(msg);
-            throw new ResourceNotFoundException(msg);
-        }
-        if (states.isEmpty()) {
-            return optionalMentor.get().getMentees();
-        } else {
-            return menteeRepository.findAllByMentorIdAndStateIn(optionalMentor.get().getId(), states);
-        }
-    }
-
-    /**
      * Retrieves the applied {@link Mentor} objects of the {@link Mentee}
      *
      * @param programId which is the id of the {@link Program}

--- a/src/test/java/org/sefglobal/scholarx/controller/IntrospectionControllerTest.java
+++ b/src/test/java/org/sefglobal/scholarx/controller/IntrospectionControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import javax.servlet.http.Cookie;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -23,7 +24,8 @@ public class IntrospectionControllerTest {
     private MockMvc mockMvc;
     @MockBean
     private IntrospectionService introspectionService;
-    final Cookie profileIdCookie = new Cookie("profileId", "1");
+    private final Long programId = 1L;
+    private final Cookie profileIdCookie = new Cookie("profileId", "1");
 
     @Test
     void getLoggedInUser_withValidData_thenReturns200() throws Exception {
@@ -110,5 +112,23 @@ public class IntrospectionControllerTest {
         mockMvc.perform(get("/me/programs/mentor")
                 .cookie(profileIdCookie))
                 .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void getMentees_withValidData_thenReturns200() throws Exception {
+        mockMvc.perform(get("/me/programs/{id}/mentees", programId)
+                                .cookie(profileIdCookie))
+               .andExpect(status().isOk());
+    }
+
+    @Test
+    void getMentees_withUnavailableData_thenReturns204() throws Exception {
+        doThrow(NoContentException.class)
+                .when(introspectionService)
+                .getMentees(anyLong(), anyLong(), any());
+
+        mockMvc.perform(get("/me/programs/{id}/mentees", programId)
+                                .cookie(profileIdCookie))
+               .andExpect(status().isNoContent());
     }
 }

--- a/src/test/java/org/sefglobal/scholarx/controller/ProgramControllerTest.java
+++ b/src/test/java/org/sefglobal/scholarx/controller/ProgramControllerTest.java
@@ -256,24 +256,6 @@ public class ProgramControllerTest {
     }
 
     @Test
-    void getMenteesOfMentor_withValidData_thenReturns200() throws Exception {
-        mockMvc.perform(get("/admin/programs/{id}/mentor/mentees", programId)
-                .cookie(profileIdCookie))
-                .andExpect(status().isOk());
-    }
-
-    @Test
-    void getMenteesOfMentor_withUnavailableData_thenReturns404() throws Exception {
-        doThrow(ResourceNotFoundException.class)
-                .when(programService)
-                .getAllMenteesOfMentor(anyLong(), anyLong(), any());
-
-        mockMvc.perform(get("/admin/programs/{id}/mentor/mentees", programId)
-                .cookie(profileIdCookie))
-                .andExpect(status().isNotFound());
-    }
-
-    @Test
     void getAppliedMentors_withValidData_thenReturns200() throws Exception {
         mockMvc.perform(get("/programs/{id}/mentee/mentors", programId)
                 .cookie(profileIdCookie))

--- a/src/test/java/org/sefglobal/scholarx/service/IntrospectionServiceTest.java
+++ b/src/test/java/org/sefglobal/scholarx/service/IntrospectionServiceTest.java
@@ -8,12 +8,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.sefglobal.scholarx.exception.NoContentException;
 import org.sefglobal.scholarx.exception.ResourceNotFoundException;
 import org.sefglobal.scholarx.exception.UnauthorizedException;
+import org.sefglobal.scholarx.model.Mentee;
 import org.sefglobal.scholarx.model.Mentor;
 import org.sefglobal.scholarx.repository.MenteeRepository;
 import org.sefglobal.scholarx.repository.MentorRepository;
 import org.sefglobal.scholarx.repository.ProfileRepository;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,7 +33,8 @@ public class IntrospectionServiceTest {
     private MentorRepository mentorRepository;
     @InjectMocks
     private IntrospectionService introspectionService;
-    final long profileId = 1L;
+    private final Long programId = 1L;
+    private final long profileId = 1L;
 
     @Test
     void getLoggedInUser_withUnavailableData_thenThrowResourceNotFound() {
@@ -111,5 +114,19 @@ public class IntrospectionServiceTest {
         assertThat(thrown)
                 .isInstanceOf(NoContentException.class)
                 .hasMessage("Error, User has not enrolled in any program as a mentor.");
+    }
+
+    @Test
+    void getAllMentees_withUnavailableData_thenThrowNoContent() {
+        doReturn(new ArrayList<Mentee>())
+                .when(menteeRepository)
+                .findAllByProgramIdAndProfileId(anyLong(), anyLong());
+
+        Throwable thrown = catchThrowable(
+                () -> introspectionService
+                        .getMentees(programId, profileId, Collections.emptyList()));
+        assertThat(thrown)
+                .isInstanceOf(NoContentException.class)
+                .hasMessage("No mentees exist for the required program: 1 for the profile: 1");
     }
 }

--- a/src/test/java/org/sefglobal/scholarx/service/ProgramServiceTest.java
+++ b/src/test/java/org/sefglobal/scholarx/service/ProgramServiceTest.java
@@ -285,20 +285,6 @@ public class ProgramServiceTest {
     }
 
     @Test
-    void getAllMenteesOfMentor_withUnavailableData_thenThrowResourceNotFound() {
-        doReturn(Optional.empty())
-                .when(mentorRepository)
-                .findByProfileIdAndProgramId(anyLong(), anyLong());
-
-        Throwable thrown = catchThrowable(
-                () -> programService.getAllMenteesOfMentor(programId, profileId, Collections.emptyList()));
-        assertThat(thrown)
-                .isInstanceOf(ResourceNotFoundException.class)
-                .hasMessage("Error, Mentor by profile id: 1 and " +
-                            "program id: 1 cannot be updated. Mentor doesn't exist.");
-    }
-
-    @Test
     void getAppliedMentorsOfMentee_withUnavailableData_thenThrowNoContent() {
         doReturn(new ArrayList<>())
                 .when(menteeRepository)


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix #87 

## Goals
1. Remove existing admin api with method name getMenteesOfMentor
2. Create new user api

## Approach
1. Removed the unnecessary API with all it's test cases
2. Added the new user API
3. Added service logic for the API
4. Created test cases for the new API

### Screenshots
N/A
  
### Preview Link
N/A

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related PRs
N/A

## Test environment
macOS 10.15, JDK 1.8

## Learning
N/A