### PR TITLE
Add dockerfiles and kube-config files

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:8-jdk-alpine
+ARG JAR_FILE=target/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/auth-server/Dockerfile
+++ b/auth-server/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:8-jdk-alpine
+ARG JAR_FILE=target/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/kube-config/auth-server-deployment.yaml
+++ b/kube-config/auth-server-deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.image-pull-policy: Never
+    kompose.version: 1.22.0 (HEAD)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: auth-server
+  name: auth-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: auth-server
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert
+        kompose.image-pull-policy: Never
+        kompose.version: 1.22.0 (HEAD)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: auth-server
+    spec:
+      containers:
+        - env:
+            - name: DATABASE_HOST
+              value: mysql-db
+            - name: DATABASE_NAME
+              value: scholarx
+            - name: DATABASE_PASSWORD
+              value: password
+            - name: DATABASE_PORT
+              value: "3306"
+            - name: DATABASE_USER
+              value: user
+          image: auth-server
+          imagePullPolicy: Never
+          name: auth-server
+          ports:
+            - containerPort: 8080
+          resources: {}
+      restartPolicy: Always
+status: {}

--- a/kube-config/auth-server-service.yaml
+++ b/kube-config/auth-server-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.image-pull-policy: Never
+    kompose.version: 1.22.0 (HEAD)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: auth-server
+  name: auth-server
+spec:
+  ports:
+    - name: "8080"
+      port: 8080
+      targetPort: 8080
+  selector:
+    io.kompose.service: auth-server
+status:
+  loadBalancer: {}

--- a/kube-config/docker-compose.yml
+++ b/kube-config/docker-compose.yml
@@ -1,0 +1,43 @@
+version: '3'
+
+services:
+
+  mysql-db:
+    image: mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_DATABASE=scholarx
+      - MYSQL_USER=user
+      - MYSQL_PASSWORD=password
+    ports:
+      - 3306:3306
+
+  scholarx-app:
+    image: scholarx
+    depends_on:
+      - mysql-db
+    ports:
+      - 8080:8080
+    environment:
+      - DATABASE_HOST=mysql-db
+      - DATABASE_USER=user
+      - DATABASE_PASSWORD=password
+      - DATABASE_NAME=scholarx
+      - DATABASE_PORT=3306
+    labels:
+      kompose.image-pull-policy: "Never"
+
+  auth-server:
+    image: auth-server 
+    depends_on: 
+      - mysql-db
+    ports:
+      - 8080:8080
+    environment:
+      - DATABASE_HOST=mysql-db
+      - DATABASE_USER=user
+      - DATABASE_PASSWORD=password
+      - DATABASE_NAME=scholarx
+      - DATABASE_PORT=3306
+    labels:
+      kompose.image-pull-policy: "Never"

--- a/kube-config/ingress.yaml
+++ b/kube-config/ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sef-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - http:
+      paths:
+        - path: /
+          pathType: Prefix
+          backend:
+            service:
+              name: auth-server
+              port:
+                number: 8080
+

--- a/kube-config/mysql-db-deployment.yaml
+++ b/kube-config/mysql-db-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.22.0 (HEAD)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: mysql-db
+  name: mysql-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: mysql-db
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert
+        kompose.version: 1.22.0 (HEAD)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: mysql-db
+    spec:
+      containers:
+        - env:
+            - name: MYSQL_DATABASE
+              value: scholarx
+            - name: MYSQL_PASSWORD
+              value: password
+            - name: MYSQL_ROOT_PASSWORD
+              value: root
+            - name: MYSQL_USER
+              value: user
+          image: mysql
+          name: mysql-db
+          ports:
+            - containerPort: 3306
+          resources: {}
+      restartPolicy: Always
+status: {}

--- a/kube-config/mysql-db-service.yaml
+++ b/kube-config/mysql-db-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.22.0 (HEAD)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: mysql-db
+  name: mysql-db
+spec:
+  ports:
+    - name: "3306"
+      port: 3306
+      targetPort: 3306
+  selector:
+    io.kompose.service: mysql-db
+status:
+  loadBalancer: {}

--- a/kube-config/scholarx-app-deployment.yaml
+++ b/kube-config/scholarx-app-deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.image-pull-policy: Never
+    kompose.version: 1.22.0 (HEAD)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: scholarx-app
+  name: scholarx-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: scholarx-app
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert
+        kompose.image-pull-policy: Never
+        kompose.version: 1.22.0 (HEAD)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: scholarx-app
+    spec:
+      containers:
+        - env:
+            - name: DATABASE_HOST
+              value: mysql-db
+            - name: DATABASE_NAME
+              value: scholarx
+            - name: DATABASE_PASSWORD
+              value: password
+            - name: DATABASE_PORT
+              value: "3306"
+            - name: DATABASE_USER
+              value: user
+          image: scholarx
+          imagePullPolicy: Never
+          name: scholarx-app
+          ports:
+            - containerPort: 8080
+          resources: {}
+      restartPolicy: Always
+status: {}

--- a/kube-config/scholarx-app-service.yaml
+++ b/kube-config/scholarx-app-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.image-pull-policy: Never
+    kompose.version: 1.22.0 (HEAD)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: scholarx-app
+  name: scholarx-app
+spec:
+  ports:
+    - name: "8080"
+      port: 8080
+      targetPort: 8080
+  selector:
+    io.kompose.service: scholarx-app
+status:
+  loadBalancer: {}


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #101 

## Goals
* To keep all Kubernetes and docker configuration files in one place

## Approach
* Created two dockerfiles to containerize both modules, `app` and `auth-server`
* Used a docker-compose file and kompose to create deployment and service files for `mysql-db`, `scholarx-app`, and `auth-server`
* Created a yaml file to configure an ingress to expose `auth-server` 

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Test environment
* macOs BigSur
* minikube env on hyperkit virtual machine 

