### PR TITLE
added threads to improve email notification service #132

### DIFF
--- a/src/main/java/org/sefglobal/scholarx/service/ProgramService.java
+++ b/src/main/java/org/sefglobal/scholarx/service/ProgramService.java
@@ -127,44 +127,49 @@ public class ProgramService {
         List<Mentor> approvedMentors = mentorRepository.findAllByProgramIdAndState(id, EnrolmentState.APPROVED);
         List<Mentee> mentees = menteeRepository.findAllByProgramId(id);
 
-        switch (program.get().getState().next()) {
-            case MENTEE_APPLICATION:
-                for (Mentor mentor : mentors) {
-                    Email email = new Email();
-                    email.setEmail(mentor.getProfile().getEmail());
-                    email.setSubject(program.get().getTitle());
-                    email.setMessage("You have been " + mentor.getState().name().toLowerCase());
-                    emailUtil.sendSimpleMessage(email);
+        Thread thread = new Thread(() -> {
+            try {
+                switch (program.get().getState().next()) {
+                    case MENTEE_APPLICATION:
+                        for (Mentor mentor : mentors) {
+                            Email email = new Email();
+                            email.setEmail(mentor.getProfile().getEmail());
+                            email.setSubject(program.get().getTitle());
+                            email.setMessage("You have been " + mentor.getState().name().toLowerCase());
+                            emailUtil.sendSimpleMessage(email);
+                        }
+                        break;
+                    case MENTEE_SELECTION:
+                        for (Mentor mentor : approvedMentors) {
+                            Email email = new Email();
+                            email.setEmail(mentor.getProfile().getEmail());
+                            email.setSubject(program.get().getTitle());
+                            email.setMessage("You can approve or reject your mentees by visiting the dashboard");
+                            emailUtil.sendSimpleMessage(email);
+                        }
+                        break;
+                    case ONGOING:
+                        for (Mentor mentor : approvedMentors) {
+                            Email email = new Email();
+                            email.setEmail(mentor.getProfile().getEmail());
+                            email.setSubject(program.get().getTitle());
+                            email.setMessage("You can check your mentees by visiting the dashboard");
+                            emailUtil.sendSimpleMessage(email);
+                        }
+                        break;
+                    case MENTOR_CONFIRMATION:
+                        for (Mentee mentee : mentees) {
+                            Email email = new Email();
+                            email.setEmail(mentee.getProfile().getEmail());
+                            email.setSubject(program.get().getTitle());
+                            email.setMessage("You can check your mentor by visiting the dashboard");
+                            emailUtil.sendSimpleMessage(email);
+                        }
+                        break;
                 }
-                break;
-            case MENTEE_SELECTION:
-                for (Mentor mentor : approvedMentors) {
-                    Email email = new Email();
-                    email.setEmail(mentor.getProfile().getEmail());
-                    email.setSubject(program.get().getTitle());
-                    email.setMessage("You can approve or reject your mentees by visiting the dashboard");
-                    emailUtil.sendSimpleMessage(email);
-                }
-                break;
-            case ONGOING:
-                for (Mentor mentor : approvedMentors) {
-                    Email email = new Email();
-                    email.setEmail(mentor.getProfile().getEmail());
-                    email.setSubject(program.get().getTitle());
-                    email.setMessage("You can check your mentees by visiting the dashboard");
-                    emailUtil.sendSimpleMessage(email);
-                }
-                break;
-            case MENTOR_CONFIRMATION:
-                for (Mentee mentee : mentees) {
-                    Email email = new Email();
-                    email.setEmail(mentee.getProfile().getEmail());
-                    email.setSubject(program.get().getTitle());
-                    email.setMessage("You can check your mentor by visiting the dashboard");
-                    emailUtil.sendSimpleMessage(email);
-                }
-                break;
-        }
+            }catch (Exception ignored){}
+        });
+        thread.start();
 
         if (!program.isPresent()) {
             String msg = "Error, Program with id: " + id + " cannot be updated. " +


### PR DESCRIPTION
## Purpose
When the Current system needs to send email notifications it waits until all emails deliver then send’s the response to the front-end, the problem is it takes at least 5 seconds to send an email to one email account and get a response if there are 500 accounts to send it will take at least 41 minutes to get a response from the server.

## Goals
Improve the response speed from the backend to the frontend.

## Approach
Created a separate thread for the email sending process.

### Screenshots
![image](https://user-images.githubusercontent.com/29551090/116088092-2b477600-a6bf-11eb-8f14-e52309fc2398.png)
  
### Preview Link
<!---  This PR will be automatically deployed to surge. -->
<!---  Once you submit the PR, replace "{PR_NUMBER}" with your PR number. -->
https://pr-{PR_NUMBER}-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related PRs
<!--- List any other related PRs --> 

## Test environment
 - Computer: MacBook Pro 13inch 2020
 - OS: macOS Big Sur
 - Browser: safari
