### PR TITLE
Extend models to accommodate dynamic mentor applications

### DIFF
--- a/src/main/java/org/sefglobal/scholarx/controller/ProgramController.java
+++ b/src/main/java/org/sefglobal/scholarx/controller/ProgramController.java
@@ -5,12 +5,11 @@ import javax.validation.Valid;
 import org.sefglobal.scholarx.exception.BadRequestException;
 import org.sefglobal.scholarx.exception.NoContentException;
 import org.sefglobal.scholarx.exception.ResourceNotFoundException;
-import org.sefglobal.scholarx.model.Mentor;
-import org.sefglobal.scholarx.model.Profile;
-import org.sefglobal.scholarx.model.Program;
+import org.sefglobal.scholarx.model.*;
 import org.sefglobal.scholarx.service.ProgramService;
 import org.sefglobal.scholarx.util.EnrolmentState;
 import org.sefglobal.scholarx.util.ProgramState;
+import org.sefglobal.scholarx.util.QuestionCategory;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -61,11 +60,11 @@ public class ProgramController {
   public Mentor applyAsMentor(
     @PathVariable long id,
     Authentication authentication,
-    @Valid @RequestBody Mentor mentor
+    @Valid @RequestBody List<MentorResponse> responses
   )
     throws ResourceNotFoundException, BadRequestException {
     Profile profile = (Profile) authentication.getPrincipal();
-    return programService.applyAsMentor(id, profile.getId(), mentor);
+    return programService.applyAsMentor(id, profile.getId(), responses);
   }
 
   @GetMapping("/{id}/mentor")
@@ -77,18 +76,6 @@ public class ProgramController {
     throws ResourceNotFoundException {
     Profile profile = (Profile) authentication.getPrincipal();
     return programService.getLoggedInMentor(id, profile.getId());
-  }
-
-  @PutMapping("/{id}/application")
-  @ResponseStatus(HttpStatus.OK)
-  public Mentor updateMentorData(
-    @PathVariable long id,
-    Authentication authentication,
-    @Valid @RequestBody Mentor mentor
-  )
-    throws ResourceNotFoundException, BadRequestException {
-    Profile profile = (Profile) authentication.getPrincipal();
-    return programService.updateMentorData(profile.getId(), id, mentor);
   }
 
   @GetMapping("/{id}/mentee/mentors")
@@ -116,5 +103,38 @@ public class ProgramController {
     throws ResourceNotFoundException, NoContentException {
     Profile profile = (Profile) authentication.getPrincipal();
     return programService.getSelectedMentor(id, profile.getId());
+  }
+
+  @GetMapping("/{id}/questions/{category}")
+  @ResponseStatus(HttpStatus.OK)
+  public List<Question> getQuestions(@PathVariable long id,
+                                     @PathVariable QuestionCategory category) throws ResourceNotFoundException {
+    return programService.getQuestions(id, category);
+  }
+
+  @GetMapping("/{id}/responses/mentor")
+  @ResponseStatus(HttpStatus.OK)
+  public List<MentorResponse> getMentorResponses(
+          @PathVariable long id,
+          Authentication authentication,
+          @RequestParam(required = false) Long mentorId
+  )
+  throws ResourceNotFoundException {
+    if (mentorId != null) {
+      return programService.getMentorResponses(mentorId);
+    }
+    Profile profile = (Profile) authentication.getPrincipal();
+    return programService.getMentorResponses(id, profile.getId());
+  }
+
+  @PutMapping("/{id}/responses/mentor")
+  public List<MentorResponse> editMentorResponses(
+          @PathVariable long id,
+          Authentication authentication,
+          @RequestBody List<MentorResponse> responses
+  )
+  throws ResourceNotFoundException{
+    Profile profile = (Profile) authentication.getPrincipal();
+    return programService.editMentorResponses(id, profile.getId(), responses);
   }
 }

--- a/src/main/java/org/sefglobal/scholarx/controller/admin/ProgramController.java
+++ b/src/main/java/org/sefglobal/scholarx/controller/admin/ProgramController.java
@@ -6,8 +6,10 @@ import org.sefglobal.scholarx.exception.ResourceNotFoundException;
 import org.sefglobal.scholarx.model.Mentee;
 import org.sefglobal.scholarx.model.Mentor;
 import org.sefglobal.scholarx.model.Program;
+import org.sefglobal.scholarx.model.Question;
 import org.sefglobal.scholarx.service.ProgramService;
 import org.sefglobal.scholarx.util.EnrolmentState;
+import org.sefglobal.scholarx.util.QuestionCategory;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -67,5 +69,13 @@ public class ProgramController {
     public List<Mentee> getAllMenteesByProgramId(@PathVariable long id)
             throws ResourceNotFoundException {
         return programService.getAllMenteesByProgramId(id);
+    }
+
+    @PostMapping("/{id}/questions/{category}")
+    @ResponseStatus(HttpStatus.OK)
+    public List<Question> addQuestions(@PathVariable long id,
+                                       @PathVariable QuestionCategory category,
+                                       @RequestBody List<Question> questions) throws ResourceNotFoundException {
+        return programService.addQuestions(id, category, questions);
     }
 }

--- a/src/main/java/org/sefglobal/scholarx/model/Mentor.java
+++ b/src/main/java/org/sefglobal/scholarx/model/Mentor.java
@@ -2,7 +2,6 @@ package org.sefglobal.scholarx.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
@@ -14,38 +13,14 @@ import java.util.List;
 @JsonIgnoreProperties({"createdAt", "updatedAt", "mentees"})
 public class Mentor extends EnrolledUser {
 
-    @Column
-    private String application;
-
-    @Column
-    private String prerequisites;
+    @OneToMany(mappedBy = "mentor")
+    private List<MentorResponse> mentorResponses;
 
     public Mentor() {
     }
 
-    public Mentor(String application, String prerequisites) {
-        this.application = application;
-        this.prerequisites = prerequisites;
-    }
-
     @OneToMany(mappedBy = "mentor")
     private List<Mentee> mentees = new ArrayList<>();
-
-    public String getApplication() {
-        return application;
-    }
-
-    public void setApplication(String application) {
-        this.application = application;
-    }
-
-    public String getPrerequisites() {
-        return prerequisites;
-    }
-
-    public void setPrerequisites(String prerequisites) {
-        this.prerequisites = prerequisites;
-    }
 
     public List<Mentee> getMentees() {
         return mentees;

--- a/src/main/java/org/sefglobal/scholarx/model/MentorResponse.java
+++ b/src/main/java/org/sefglobal/scholarx/model/MentorResponse.java
@@ -1,0 +1,66 @@
+package org.sefglobal.scholarx.model;
+
+import javax.persistence.*;
+import java.io.Serializable;
+
+@Entity
+@Table(name = "mentor_response")
+public class MentorResponse implements Serializable {
+
+    @EmbeddedId
+    MentorResponseId id;
+
+    @ManyToOne(cascade = CascadeType.ALL)
+    @MapsId("questionId")
+    @JoinColumn(name = "question_id")
+    private Question question;
+
+    @ManyToOne(cascade = CascadeType.ALL)
+    @MapsId("mentorId")
+    @JoinColumn(name = "mentor_id")
+    private Mentor mentor;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String response;
+
+    public MentorResponse() {}
+
+    public MentorResponse(Question question, Mentor mentor, String response) {
+        this.id = new MentorResponseId(question.getId(), mentor.getId());
+        this.question = question;
+        this.mentor = mentor;
+        this.response = response;
+    }
+
+    public MentorResponseId getId() {
+        return id;
+    }
+
+    public void setId(MentorResponseId id) {
+        this.id = id;
+    }
+
+    public Question getQuestion() {
+        return question;
+    }
+
+    public void setQuestion(Question question) {
+        this.question = question;
+    }
+
+    public Mentor getMentor() {
+        return mentor;
+    }
+
+    public void setMentor(Mentor mentor) {
+        this.mentor = mentor;
+    }
+
+    public String getResponse() {
+        return response;
+    }
+
+    public void setResponse(String response) {
+        this.response = response;
+    }
+}

--- a/src/main/java/org/sefglobal/scholarx/model/MentorResponseId.java
+++ b/src/main/java/org/sefglobal/scholarx/model/MentorResponseId.java
@@ -1,0 +1,50 @@
+package org.sefglobal.scholarx.model;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+public class MentorResponseId implements Serializable {
+    @Column(name = "question_id")
+    private long questionId;
+    @Column(name = "mentor_id")
+    private long mentorId;
+
+    public MentorResponseId() {}
+
+    public MentorResponseId(long questionId, long mentorId) {
+        this.questionId = questionId;
+        this.mentorId = mentorId;
+    }
+
+    public void setQuestionId(long questionId) {
+        this.questionId = questionId;
+    }
+
+    public long getQuestionId() {
+        return questionId;
+    }
+
+    public void setMentorId(long mentorId) {
+        this.mentorId = mentorId;
+    }
+
+    public long getMentorId() {
+        return mentorId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(questionId, mentorId);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        MentorResponseId id = (MentorResponseId) obj;
+        return id.mentorId == this.mentorId && id.questionId == this.questionId;
+    }
+}

--- a/src/main/java/org/sefglobal/scholarx/model/Program.java
+++ b/src/main/java/org/sefglobal/scholarx/model/Program.java
@@ -36,6 +36,9 @@ public class Program extends BaseScholarxModel {
   private ProgramState state;
 
   @OneToMany(mappedBy = "program")
+  private List<Question> questions;
+
+  @OneToMany(mappedBy = "program")
   private List<EnrolledUser> enrolledUsers = new ArrayList<>();
 
   public Program() {}

--- a/src/main/java/org/sefglobal/scholarx/model/Question.java
+++ b/src/main/java/org/sefglobal/scholarx/model/Question.java
@@ -1,0 +1,56 @@
+package org.sefglobal.scholarx.model;
+
+import org.sefglobal.scholarx.util.QuestionCategory;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Entity
+@Table(name = "question")
+public class Question extends BaseScholarxModel{
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String question;
+
+    @Column(nullable = false)
+    private QuestionCategory category;
+
+    @ManyToOne
+    @JoinColumn(name = "program_id")
+    private Program program;
+
+    @OneToMany(mappedBy = "question")
+    private List<MentorResponse> mentorResponses;
+
+    public Question() {}
+
+    public Question(String question, QuestionCategory category, Program program) {
+        this.question = question;
+        this.category = category;
+        this.program = program;
+    }
+
+    public String getQuestion() {
+        return question;
+    }
+
+    public void setQuestion(String question) {
+        this.question = question;
+    }
+
+    public QuestionCategory getCategory() {
+        return category;
+    }
+
+    public void setCategory(QuestionCategory category) {
+        this.category = category;
+    }
+
+    public Program getProgram() {
+        return program;
+    }
+
+    public void setProgram(Program program) {
+        this.program = program;
+    }
+}

--- a/src/main/java/org/sefglobal/scholarx/repository/MentorResponseRepository.java
+++ b/src/main/java/org/sefglobal/scholarx/repository/MentorResponseRepository.java
@@ -1,0 +1,11 @@
+package org.sefglobal.scholarx.repository;
+
+import org.sefglobal.scholarx.model.MentorResponse;
+import org.sefglobal.scholarx.model.MentorResponseId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MentorResponseRepository extends JpaRepository<MentorResponse, MentorResponseId> {
+    List<MentorResponse> getAllByMentorId(long mentorId);
+}

--- a/src/main/java/org/sefglobal/scholarx/repository/QuestionRepository.java
+++ b/src/main/java/org/sefglobal/scholarx/repository/QuestionRepository.java
@@ -1,0 +1,12 @@
+package org.sefglobal.scholarx.repository;
+
+import org.sefglobal.scholarx.model.Program;
+import org.sefglobal.scholarx.model.Question;
+import org.sefglobal.scholarx.util.QuestionCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+    List<Question> getAllByCategoryAndProgramId(QuestionCategory category, long programId);
+}

--- a/src/main/java/org/sefglobal/scholarx/service/ProgramService.java
+++ b/src/main/java/org/sefglobal/scholarx/service/ProgramService.java
@@ -4,21 +4,17 @@ import org.sefglobal.scholarx.exception.BadRequestException;
 import org.sefglobal.scholarx.exception.NoContentException;
 import org.sefglobal.scholarx.exception.ResourceNotFoundException;
 import org.sefglobal.scholarx.model.*;
-import org.sefglobal.scholarx.repository.MenteeRepository;
-import org.sefglobal.scholarx.repository.MentorRepository;
-import org.sefglobal.scholarx.repository.ProfileRepository;
-import org.sefglobal.scholarx.repository.ProgramRepository;
+import org.sefglobal.scholarx.repository.*;
 import org.sefglobal.scholarx.util.EmailUtil;
 import org.sefglobal.scholarx.util.EnrolmentState;
 import org.sefglobal.scholarx.util.ProgramState;
+import org.sefglobal.scholarx.util.QuestionCategory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 @Service
 public class ProgramService {
@@ -27,6 +23,8 @@ public class ProgramService {
     private final ProfileRepository profileRepository;
     private final MentorRepository mentorRepository;
     private final MenteeRepository menteeRepository;
+    private final QuestionRepository questionRepository;
+    private final MentorResponseRepository mentorResponseRepository;
 
     @Autowired
     private EmailUtil emailUtil;
@@ -34,11 +32,15 @@ public class ProgramService {
     public ProgramService(ProgramRepository programRepository,
                           ProfileRepository profileRepository,
                           MentorRepository mentorRepository,
-                          MenteeRepository menteeRepository) {
+                          MenteeRepository menteeRepository,
+                          QuestionRepository questionRepository,
+                          MentorResponseRepository mentorResponseRepository) {
         this.programRepository = programRepository;
         this.profileRepository = profileRepository;
         this.mentorRepository = mentorRepository;
         this.menteeRepository = menteeRepository;
+        this.questionRepository = questionRepository;
+        this.mentorResponseRepository = mentorResponseRepository;
     }
 
     /**
@@ -247,11 +249,11 @@ public class ProgramService {
     }
 
     /**
-     * Create new {@link Mentor}
+     * Create new {@link Mentor} and Record new {@link MentorResponse} list
      *
      * @param programId which is the program id for the requesting {@link Program}
      * @param profileId which is the profile id of the applying user's {@link Profile}
-     * @param mentor    which holds the data to be added
+     * @param responses which holds the responses to be added
      * @return the created {@link Mentor}
      *
      * @throws ResourceNotFoundException is thrown if the applying {@link Program} doesn't exist
@@ -259,7 +261,7 @@ public class ProgramService {
      * @throws BadRequestException is thrown if the applying {@link Program} is
      * not in the applicable {@link ProgramState}
      */
-    public Mentor applyAsMentor(long programId, long profileId, Mentor mentor)
+    public Mentor applyAsMentor(long programId, long profileId, List<MentorResponse> responses)
             throws ResourceNotFoundException, BadRequestException {
         Optional<Program> optionalProgram = programRepository.findById(programId);
         if (!optionalProgram.isPresent()) {
@@ -283,10 +285,24 @@ public class ProgramService {
             throw new ResourceNotFoundException(msg);
         }
 
+        Mentor mentor = new Mentor();
         mentor.setProfile(optionalProfile.get());
         mentor.setProgram(optionalProgram.get());
         mentor.setState(EnrolmentState.PENDING);
-        return mentorRepository.save(mentor);
+        Mentor savedMentor = mentorRepository.save(mentor);
+        List<MentorResponse> processedResponses = new ArrayList<>();
+        for (MentorResponse r: responses) {
+            Question question = questionRepository.getOne(r.getQuestion().getId());
+            MentorResponse updatedResponse = new MentorResponse(question, savedMentor, r.getResponse());
+            processedResponses.add(updatedResponse);
+        }
+        try {
+            mentorResponseRepository.saveAll(processedResponses);
+        } catch (Exception e) {
+            mentorRepository.delete(savedMentor);
+            throw e;
+        }
+        return savedMentor;
     }
 
     /**
@@ -311,51 +327,71 @@ public class ProgramService {
     }
 
     /**
-     * Update the application and prerequisites of a {@link Mentor}
+     * Retrieves the {@link MentorResponse} List of a {@link Mentor}
      *
-     * @param profileId which is the Profile id of the {@link Mentor} to be updated
-     * @param programId which is the Program id of the {@link Mentor} to be updated
-     * @param mentor    with the application and prerequisites of the mentor to be updated
-     * @return the updated {@link Mentor}
-     *
-     * @throws ResourceNotFoundException is thrown if the {@link Mentor} doesn't exist
-     * @throws BadRequestException       if the {@link Mentor} is not in the valid state
+     * @param programId which is the Id of the {@link Program}
+     * @param profileId which is the profile Id of the {@link Mentor}
+     * @return {@link MentorResponse} list
+     * @throws ResourceNotFoundException if a mentor doesn't exist by the given programId and profileId
      */
-    public Mentor updateMentorData(long profileId, long programId, Mentor mentor)
-            throws ResourceNotFoundException, BadRequestException {
-        Optional<Mentor> optionalMentor = mentorRepository.findByProfileIdAndProgramId(profileId, programId);
-        if (!optionalMentor.isPresent()) {
+    public List<MentorResponse> getMentorResponses(long programId, long profileId) throws ResourceNotFoundException {
+        Optional<Mentor> mentor = mentorRepository.findByProfileIdAndProgramId(profileId, programId);
+        if (!mentor.isPresent()) {
             String msg = "Error, Mentor by profile id: " + profileId + " and " +
-                         "program id: " + programId + " cannot be updated. " +
-                         "Mentor doesn't exist.";
+                    "program id: " + programId + " cannot be found. " +
+                    "Mentor doesn't exist.";
             log.error(msg);
             throw new ResourceNotFoundException(msg);
         }
+        return mentorResponseRepository.getAllByMentorId(mentor.get().getId());
+    }
 
-        Mentor existingMentor = optionalMentor.get();
-        if (!mentor.getApplication().isEmpty()) {
-            if (EnrolmentState.PENDING.equals(existingMentor.getState())) {
-                existingMentor.setApplication(mentor.getApplication());
-            } else {
-                String msg = "Error, Application cannot be updated. " +
-                             "Mentor is not in a valid state.";
-                log.error(msg);
-                throw new BadRequestException(msg);
-            }
+    /**
+     * Retrives the {@link MentorResponse} List of a {@link Mentor}
+     *
+     * @param mentorId which is the id of the {@link Mentor}
+     * @return {@link MentorResponse} list
+     * @throws ResourceNotFoundException if a mentor doesn't exist by the given mentorId
+     */
+    public List<MentorResponse> getMentorResponses(long mentorId) throws ResourceNotFoundException {
+        Optional<Mentor> mentor = mentorRepository.findById(mentorId);
+        if (!mentor.isPresent()) {
+            String msg = "Error, Mentor by mentor id: " + mentorId + " cannot be found. " +
+                    "Mentor doesn't exist.";
+            log.error(msg);
+            throw new ResourceNotFoundException(msg);
         }
-        if (!mentor.getPrerequisites().isEmpty()) {
-            if (EnrolmentState.APPROVED.isHigherThanOrEqual(existingMentor.getState())) {
-                if (ProgramState.MENTEE_APPLICATION.isHigherThan(existingMentor.getProgram().getState())) {
-                    existingMentor.setPrerequisites(mentor.getPrerequisites());
-                } else {
-                    String msg = "Error, Prerequisites cannot be updated. " +
-                                 "Mentor is not in a valid state.";
-                    log.error(msg);
-                    throw new BadRequestException(msg);
-                }
-            }
+        return mentorResponseRepository.getAllByMentorId(mentor.get().getId());
+    }
+
+    /**
+     * Update the application question responses of a {@link Mentor}
+     *
+     * @param programId which is the id of the program
+     * @param profileId which is the profile id of the {@link Mentor}
+     * @param mentorResponses list of {@link MentorResponse}s to be updated
+     * @return the updated list of {@link MentorResponse}
+     * @throws ResourceNotFoundException if a mentor doesn't exist by the given profileId and programId
+     */
+    public List<MentorResponse> editMentorResponses(long programId,
+                                                    long profileId,
+                                                    List<MentorResponse> mentorResponses)
+            throws ResourceNotFoundException {
+        Optional<Mentor> mentor = mentorRepository.findByProfileIdAndProgramId(profileId, programId);
+        if (!mentor.isPresent()) {
+            String msg = "Error, Mentor by profile id: " + profileId + " and " +
+                    "program id: " + programId + " cannot be found. " +
+                    "Mentor doesn't exist.";
+            log.error(msg);
+            throw new ResourceNotFoundException(msg);
         }
-        return mentorRepository.save(existingMentor);
+        List<MentorResponse> updatedMentorResponses = new ArrayList<>();
+        for (MentorResponse response: mentorResponses) {
+            MentorResponse queriedResponse = mentorResponseRepository.getOne(response.getId());
+            queriedResponse.setResponse(response.getResponse());
+            updatedMentorResponses.add(queriedResponse);
+        }
+        return mentorResponseRepository.saveAll(updatedMentorResponses);
     }
 
     /**
@@ -418,5 +454,48 @@ public class ProgramService {
         String msg = "Error, Mentee is not approved by any mentor yet.";
         log.error(msg);
         throw new NoContentException(msg);
+    }
+
+    /**
+     * Retrieves the {@link Question} list for a given {@link Program} and a {@link QuestionCategory}
+     *
+     * @param programId which is the if of the {@link Program}
+     * @param category which is the identifier of if the required set of questions are mentor ones or mentee ones
+     * @return {@link Question} Object list
+     * @throws ResourceNotFoundException if the {@link Program} doesn't exist
+     */
+    public List<Question> getQuestions(long programId, QuestionCategory category) throws ResourceNotFoundException {
+        Optional<Program> program = programRepository.findById(programId);
+        if (!program.isPresent()) {
+            String msg = "Error, Program by id: " + programId + " doesn't exist.";
+            log.error(msg);
+            throw new ResourceNotFoundException(msg);
+        }
+        return questionRepository.getAllByCategoryAndProgramId(category, program.get().getId());
+    }
+
+    /**
+     *Adds new {@link Question} objects to the {@link Program} mentor/mentee application forms
+     *
+     * @param programId which is the id of the {@link Program}
+     * @param category which is the identifier of whether the question is a {@link Mentor} one or a {@link Mentee} one
+     * @param questions which is the list of questions
+     * @return {@link Question} Object list
+     * @throws ResourceNotFoundException if the {@link Program} doesn't exist
+     */
+    public List<Question> addQuestions(long programId, QuestionCategory category, List<Question> questions) throws ResourceNotFoundException {
+        Optional<Program> program = programRepository.findById(programId);
+        if (!program.isPresent()) {
+            String msg = "Error, Program by id: " + programId + " doesn't exist.";
+            log.error(msg);
+            throw new ResourceNotFoundException(msg);
+        }
+        List<Question> processedQuestions = new ArrayList<>();
+        for (Question q: questions) {
+            q.setProgram(program.get());
+            q.setCategory(category);
+            processedQuestions.add(q);
+        }
+        return questionRepository.saveAll(processedQuestions);
     }
 }

--- a/src/main/java/org/sefglobal/scholarx/util/QuestionCategory.java
+++ b/src/main/java/org/sefglobal/scholarx/util/QuestionCategory.java
@@ -1,0 +1,6 @@
+package org.sefglobal.scholarx.util;
+
+public enum QuestionCategory {
+    MENTEE,
+    MENTOR;
+}


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #139 

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
* To extend models to accommodate dynamic mentor applications

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
* Introduced two new models, 
  * Question
  * MentorResponses
* Removed attributes `application` and `prerequisites` from `mentor` with the related service methods and controllers 
* Added four new endpoints and update one existing to be compatible with the above new models
  * Add Questions
  * Get Questions
  * Apply as a mentor (Updated)
  * Get mentor responses
  * Edit Mentor Responses

More Info : [SEF Hive: ScholarX Model Update to Improve the Mentor Application](https://sef.discourse.group/t/scholarx-model-update-to-improve-the-mentor-application/259?u=gravewalker)

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Test environment
- Postman
- Java Oracle 8
- Apache Maven 3.6.3
- macOS Big Sur

## Learning
- https://www.baeldung.com/jpa-many-to-many
- https://stackoverflow.com/questions/46740624/org-springframework-orm-jpa-jpasystemexception-could-not-set-field-value-post
- https://stackoverflow.com/questions/3585034/how-to-map-a-composite-key-with-jpa-and-hibernate