### PR TITLE
Prevent mentors from editing application in wrong states

### DIFF
--- a/src/main/java/org/sefglobal/scholarx/controller/ProgramController.java
+++ b/src/main/java/org/sefglobal/scholarx/controller/ProgramController.java
@@ -133,7 +133,7 @@ public class ProgramController {
           Authentication authentication,
           @RequestBody List<MentorResponse> responses
   )
-  throws ResourceNotFoundException{
+  throws ResourceNotFoundException, BadRequestException {
     Profile profile = (Profile) authentication.getPrincipal();
     return programService.editMentorResponses(id, profile.getId(), responses);
   }

--- a/src/main/java/org/sefglobal/scholarx/service/ProgramService.java
+++ b/src/main/java/org/sefglobal/scholarx/service/ProgramService.java
@@ -343,11 +343,12 @@ public class ProgramService {
      * @param mentorResponses list of {@link MentorResponse}s to be updated
      * @return the updated list of {@link MentorResponse}
      * @throws ResourceNotFoundException if a mentor doesn't exist by the given profileId and programId
+     * @throws BadRequestException is thrown if the {@link Program} is not in the valid {@link ProgramState}
      */
     public List<MentorResponse> editMentorResponses(long programId,
                                                     long profileId,
                                                     List<MentorResponse> mentorResponses)
-            throws ResourceNotFoundException {
+            throws ResourceNotFoundException, BadRequestException {
         Optional<Mentor> mentor = mentorRepository.findByProfileIdAndProgramId(profileId, programId);
         if (!mentor.isPresent()) {
             String msg = "Error, Mentor by profile id: " + profileId + " and " +
@@ -356,6 +357,14 @@ public class ProgramService {
             log.error(msg);
             throw new ResourceNotFoundException(msg);
         }
+
+        if (!ProgramState.MENTOR_APPLICATION.equals(mentor.get().getProgram().getState())) {
+            String msg = "Error, Unable to edit mentor application. " +
+                    "Program with id: " + programId + " is not in the valid state.";
+            log.error(msg);
+            throw new BadRequestException(msg);
+        }
+
         List<MentorResponse> updatedMentorResponses = new ArrayList<>();
         for (MentorResponse response: mentorResponses) {
             MentorResponse queriedResponse = mentorResponseRepository.getOne(response.getId());


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #181 

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
Preventing mentors from editing the mentor responses (application) after the MENTOR_APPLICATION period

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
Validated the state using the service method

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related PRs
<!--- List any other related PRs --> 
N/A

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 
MacOS Big Sur
IntelliJ Idea
Google Chrome

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
N/A