### PR TITLE
Fix exception caused by null profile image

### DIFF
--- a/src/main/java/org/sefglobal/scholarx/service/AuthUserService.java
+++ b/src/main/java/org/sefglobal/scholarx/service/AuthUserService.java
@@ -67,11 +67,16 @@ public class AuthUserService extends DefaultOAuth2UserService {
 
     @SuppressWarnings("rawtypes")
     public void populateImageUrl(Map<String, Object> attributes) {
-        Map profilePictureObject = (Map<?, ?>) attributes.get("profilePicture");
-        Map imageMetaData = (Map<?, ?>) profilePictureObject.get("displayImage~");
-        List<?> elements = (List<?>) imageMetaData.get("elements");
-        List<?> identifiers = (List<?>) ((Map<?, ?>) elements.get(0)).get("identifiers");
-        Map image = (Map<?, ?>) identifiers.get(0);
-        attributes.put("imageUrl", image.get("identifier"));
+        if (attributes.get("profilePicture") != null) {
+            Map profilePictureObject = (Map<?, ?>) attributes.get("profilePicture");
+            Map imageMetaData = (Map<?, ?>) profilePictureObject.get("displayImage~");
+            List<?> elements = (List<?>) imageMetaData.get("elements");
+            List<?> identifiers = (List<?>) ((Map<?, ?>) elements.get(0)).get("identifiers");
+            Map image = (Map<?, ?>) identifiers.get(0);
+            attributes.put("imageUrl", image.get("identifier"));
+        } else {
+            // Default profile image (If user has no LinkedIn profile image)
+            attributes.put("imageUrl", "https://res.cloudinary.com/dsxobn1ln/image/upload/v1626966152/profile-pic_hvfryw.jpg");
+        }
     }
 }


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix #183

## Goals
Fix the exception thrown when users with new LinkedIn accounts without a profile image attempt to sign in.

## Approach

- Uploaded default profile image to be displayed to SEF Cloudinary Storage
- Changed code in `service/AuthUserService` to attach default image if LinkedIn profile image is null

### Screenshots
<img src=https://i.imgur.com/sIoTlXO.png />

### Preview Link
https://pr-184-sef-site.surge.sh/

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Test environment
MacOS Big Sur
Google Chrome
