### PR TITLE
Prevent admins from setting invalid mentor states

### DIFF
--- a/src/main/java/org/sefglobal/scholarx/controller/admin/MentorController.java
+++ b/src/main/java/org/sefglobal/scholarx/controller/admin/MentorController.java
@@ -2,6 +2,8 @@ package org.sefglobal.scholarx.controller.admin;
 
 import java.util.Map;
 import javax.validation.Valid;
+
+import org.sefglobal.scholarx.exception.BadRequestException;
 import org.sefglobal.scholarx.exception.ResourceNotFoundException;
 import org.sefglobal.scholarx.model.Mentor;
 import org.sefglobal.scholarx.service.MentorService;
@@ -28,7 +30,7 @@ public class MentorController {
     @ResponseStatus(HttpStatus.OK)
     public Mentor updateState(@PathVariable long id,
                               @Valid @RequestBody Map<String, EnrolmentState> payload)
-            throws ResourceNotFoundException {
+            throws ResourceNotFoundException, BadRequestException {
         return mentorService.updateState(id, payload.get("state"));
     }
 }

--- a/src/main/java/org/sefglobal/scholarx/service/MentorService.java
+++ b/src/main/java/org/sefglobal/scholarx/service/MentorService.java
@@ -74,7 +74,10 @@ public class MentorService {
     public Mentor updateState(long id, EnrolmentState enrolmentState)
             throws ResourceNotFoundException, BadRequestException {
         if (!eligibleEnrolmentStatesForMentors.contains(enrolmentState)) {
-            throw new BadRequestException("Eligible states for mentors are " + eligibleEnrolmentStatesForMentors + " but received " + enrolmentState);
+            String msg = "Error, Mentor with id: " + id + " cannot be updated. " +
+                    enrolmentState + " is not an applicable state.";
+            log.error(msg);
+            throw new BadRequestException();
         }
 
         Optional<Mentor> optionalMentor = mentorRepository.findById(id);

--- a/src/main/java/org/sefglobal/scholarx/service/MentorService.java
+++ b/src/main/java/org/sefglobal/scholarx/service/MentorService.java
@@ -1,5 +1,6 @@
 package org.sefglobal.scholarx.service;
 
+import com.google.common.collect.ImmutableList;
 import org.sefglobal.scholarx.exception.BadRequestException;
 import org.sefglobal.scholarx.exception.NoContentException;
 import org.sefglobal.scholarx.exception.ResourceNotFoundException;
@@ -24,6 +25,7 @@ public class MentorService {
     private final MentorRepository mentorRepository;
     private final MenteeRepository menteeRepository;
     private final ProfileRepository profileRepository;
+    private final List<EnrolmentState> eligibleEnrolmentStatesForMentors = ImmutableList.of(EnrolmentState.APPROVED, EnrolmentState.REJECTED);
 
     public MentorService(MentorRepository mentorRepository,
                          MenteeRepository menteeRepository,
@@ -66,11 +68,15 @@ public class MentorService {
      * @param id             which is the {@link Mentor} to be updated
      * @param enrolmentState which is the {@link EnrolmentState} of the program to be updated
      * @return the updated {@link Mentor}
-     *
      * @throws ResourceNotFoundException is thrown if the requesting {@link Mentor} doesn't exist
+     * @throws BadRequestException is thrown if the requesting {@link EnrolmentState} is not eligible for a mentor
      */
     public Mentor updateState(long id, EnrolmentState enrolmentState)
-            throws ResourceNotFoundException {
+            throws ResourceNotFoundException, BadRequestException {
+        if (!eligibleEnrolmentStatesForMentors.contains(enrolmentState)) {
+            throw new BadRequestException("Eligible states for mentors are " + eligibleEnrolmentStatesForMentors + " but received " + enrolmentState);
+        }
+
         Optional<Mentor> optionalMentor = mentorRepository.findById(id);
         if (!optionalMentor.isPresent()) {
             String msg = "Error, Mentor with id: " + id + " cannot be updated. " +

--- a/src/main/java/org/sefglobal/scholarx/service/MentorService.java
+++ b/src/main/java/org/sefglobal/scholarx/service/MentorService.java
@@ -77,7 +77,7 @@ public class MentorService {
             String msg = "Error, Mentor with id: " + id + " cannot be updated. " +
                     enrolmentState + " is not an applicable state.";
             log.error(msg);
-            throw new BadRequestException();
+            throw new BadRequestException(msg);
         }
 
         Optional<Mentor> optionalMentor = mentorRepository.findById(id);

--- a/src/test/java/org/sefglobal/scholarx/service/MentorServiceTest.java
+++ b/src/test/java/org/sefglobal/scholarx/service/MentorServiceTest.java
@@ -72,7 +72,12 @@ public class MentorServiceTest {
 
     @Test
     void updateState_withInvalidData_thenThrowsBadRequestException() {
-        assertThrows(BadRequestException.class, () -> mentorService.updateState(mentorId, EnrolmentState.ASSIGNED));
+        Throwable thrown = catchThrowable(
+                () -> mentorService.updateState(mentorId, EnrolmentState.ASSIGNED));
+        assertThat(thrown)
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("Error, Mentor with id: 1 cannot be updated. " +
+                        "ASSIGNED is not an applicable state.");
     }
 
     @Test

--- a/src/test/java/org/sefglobal/scholarx/service/MentorServiceTest.java
+++ b/src/test/java/org/sefglobal/scholarx/service/MentorServiceTest.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doReturn;
@@ -57,7 +58,7 @@ public class MentorServiceTest {
 
     @Test
     void updateState_withValidData_thenReturnUpdatedData()
-            throws ResourceNotFoundException {
+            throws ResourceNotFoundException, BadRequestException {
         doReturn(Optional.of(mentor))
                 .when(mentorRepository)
                 .findById(anyLong());
@@ -67,6 +68,11 @@ public class MentorServiceTest {
 
         Mentor savedMentor = mentorService.updateState(mentorId, EnrolmentState.APPROVED);
         assertThat(savedMentor).isNotNull();
+    }
+
+    @Test
+    void updateState_withInvalidData_thenThrowsBadRequestException() {
+        assertThrows(BadRequestException.class, () -> mentorService.updateState(mentorId, EnrolmentState.ASSIGNED));
     }
 
     @Test


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix #255.

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
Prevent admins from setting invalid mentor states (Valid states - Approved, rejected)

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
Added the necessary validations and unit tests

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related PRs
<!--- List any other related PRs --> 
N/A

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 
N/A

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
N/A