### PR TITLE
Add 'REMOVED' EnrolmentState to Valid Mentor States

### DIFF
--- a/src/main/java/org/sefglobal/scholarx/service/MentorService.java
+++ b/src/main/java/org/sefglobal/scholarx/service/MentorService.java
@@ -25,7 +25,7 @@ public class MentorService {
     private final MentorRepository mentorRepository;
     private final MenteeRepository menteeRepository;
     private final ProfileRepository profileRepository;
-    private final List<EnrolmentState> eligibleEnrolmentStatesForMentors = ImmutableList.of(EnrolmentState.APPROVED, EnrolmentState.REJECTED);
+    private final List<EnrolmentState> validMentorStates = ImmutableList.of(EnrolmentState.APPROVED, EnrolmentState.REJECTED, EnrolmentState.REMOVED);
 
     public MentorService(MentorRepository mentorRepository,
                          MenteeRepository menteeRepository,
@@ -73,7 +73,7 @@ public class MentorService {
      */
     public Mentor updateState(long id, EnrolmentState enrolmentState)
             throws ResourceNotFoundException, BadRequestException {
-        if (!eligibleEnrolmentStatesForMentors.contains(enrolmentState)) {
+        if (!validMentorStates.contains(enrolmentState)) {
             String msg = "Error, Mentor with id: " + id + " cannot be updated. " +
                     enrolmentState + " is not an applicable state.";
             log.error(msg);


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix #257 

## Goals
Mentees can have the REMOVED enrolment state. So admins should be able to change the mentor's state to REMOVED state

## Approach
Add REMOVED enrolment state to eligibleEnrolmentStatesForMentors list in src/main/java/org/sefglobal/scholarx/service/MentorService.java

### Screenshots

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related PRs

## Test environment

## Learning
