### PR TITLE
Change mentee count when changing mentee states

### DIFF
--- a/src/main/java/org/sefglobal/scholarx/service/MenteeService.java
+++ b/src/main/java/org/sefglobal/scholarx/service/MenteeService.java
@@ -181,7 +181,15 @@ public class MenteeService {
             log.error(msg);
             throw new BadRequestException(msg);
         }
-        optionalMentee.get().setAssignedMentor(null);
+
+
+        if(optionalMentee.get().getState().equals(EnrolmentState.ASSIGNED)){
+            Mentor assignedMentor = optionalMentee.get().getAssignedMentor();
+            assignedMentor.setNoOfAssignedMentees(assignedMentor.getNoOfAssignedMentees() - 1);
+            optionalMentee.get().setAssignedMentor(null);
+            mentorRepository.save(assignedMentor);
+        }
+    
         optionalMentee.get().setState(enrolmentState);
         return menteeRepository.save(optionalMentee.get());
     }


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #284

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
The mentee count for a particular mentor should be reduced by one when the state of an `ASSIGNED` mentee is changed to a different state. And this condition should only be checked if the requested state change is associated with an `ASSIGNED` mentee. 

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
1. Use an if statement to check the mentee's enrolment state.
2. If it is `ASSIGNED`, change the mentee's assigned mentor to `NULL` and reduce the mentor's mentee count by one. 


### Screenshots
<!---  Include an animated GIF or screenshot if the change affects the UI.  -->

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related PRs
<!--- List any other related PRs --> 

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
