### PR TITLE
Extend the login session timeout to 2 days

### DIFF
--- a/src/main/resources/application.yml.example
+++ b/src/main/resources/application.yml.example
@@ -47,5 +47,5 @@ server:
   servlet:
     session:
       cookie:
-        max-age: 1d
-      timeout: 1d
+        max-age: 2d
+      timeout: 2d

--- a/src/main/resources/application.yml.example
+++ b/src/main/resources/application.yml.example
@@ -43,3 +43,9 @@ spring:
             enable: true
   jmx:
     unique-names: true
+server:
+  servlet:
+    session:
+      cookie:
+        max-age: 1d
+      timeout: 1d


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #329 

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
Users being able to log in and stay logged in for 2 days without having to log in through Linkedin again

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
Increased the session timeout to 2 days
Increased the session cookie max-age to 2 days

### Screenshots
<!---  Include an animated GIF or screenshot if the change affects the UI.  -->
N/A

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Related PRs
<!--- List any other related PRs --> 
N/A

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 
macOS Monterey
AdoptOpenJDK 8

Manually tested by setting 1 day as the timeout

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
N/A
