### PR TITLE
Allow requests from scholarx.sefglobal.org origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,12 @@ example:
   simplejavamail.smtp.username = example@gmail.com
   simplejavamail.smtp.password = ytrewwqlkjmkolkj
 ```
-
-6. Run the application
+6. Update the SecurityConfig.java to allow requests from the origin http://localhost:3000. The file path is scholarx/src/main/java/org/sefglobal/scholarx/config/SecurityConfig.java  
+example:
+```shell
+  configuration.setAllowedOrigins(ImmutableList.of("http://localhost:3000"));
+```
+7. Run the application
 ```shell
 mvn spring-boot:run
 ```

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ example:
 ```
 6. Update the SecurityConfig.java to allow requests from the origin http://localhost:3000. The file path is scholarx/src/main/java/org/sefglobal/scholarx/config/SecurityConfig.java  
 example:
-```shell
+```java
   configuration.setAllowedOrigins(ImmutableList.of("http://localhost:3000"));
 ```
 7. Run the application

--- a/src/main/java/org/sefglobal/scholarx/config/SecurityConfig.java
+++ b/src/main/java/org/sefglobal/scholarx/config/SecurityConfig.java
@@ -105,7 +105,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     configuration.setAllowedMethods(ImmutableList.of("GET", "POST", "PUT", "DELETE"));
     configuration.setAllowCredentials(true);
     configuration.setAllowedHeaders(ImmutableList.of("Authorization", "Cache-Control", "Content-Type"));
-    configuration.setAllowedOrigins(ImmutableList.of("http://localhost:3000"));
+    configuration.setAllowedOrigins(ImmutableList.of("https://scholarx.sefglobal.org"));
     final UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     source.registerCorsConfiguration("/**", configuration);
     return source;


### PR DESCRIPTION
## Purpose
The application throws a CORS error when using POST requests through scholarx.sefglobal.org origin
The purpose of this PR is to fix #365

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->

## Approach
changed "http://localhost:3000" to "https://scholarx.sefglobal.org" this 

### Screenshots
<!---  Include an animated GIF or screenshot if the change affects the UI.  -->

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Related PRs
<!--- List any other related PRs --> 

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
